### PR TITLE
Support for using a Spritesheet as an image atlas.

### DIFF
--- a/spritesheet/Spritesheet.hx
+++ b/spritesheet/Spritesheet.hx
@@ -111,6 +111,31 @@ class Spritesheet {
 		
 	}
 	
+
+	public function getFrameByName(frameName:String, autoGenerate:Bool = true):SpritesheetFrame {
+
+			var frameIndex:Int = 0;
+			var frame:SpritesheetFrame = null;
+
+			for (index in 0...totalFrames) {
+
+					if (frames[index].name==frameName) {
+							frameIndex = index;
+							frame = frames[index];
+							break;
+					}
+
+			}
+
+			if (frame != null && frame.bitmapData == null && autoGenerate) {
+					
+					generateBitmap (frameIndex);
+					
+			}
+
+			return frame;
+	}
+		
 	
 	public function getFrameIDs ():Array <Int> {
 		

--- a/spritesheet/data/SpritesheetFrame.hx
+++ b/spritesheet/data/SpritesheetFrame.hx
@@ -7,6 +7,7 @@ import flash.display.BitmapData;
 class SpritesheetFrame {
 	
 	
+	public var name:String;
 	public var bitmapData:BitmapData;
 	public var height:Int;
 	public var offsetX:Int;

--- a/spritesheet/importers/SparrowImporter.hx
+++ b/spritesheet/importers/SparrowImporter.hx
@@ -47,10 +47,17 @@ class SparrowImporter {
 				Std.parseInt (behaviorNodeFast.att.x), 
 				Std.parseInt (behaviorNodeFast.att.y), 
 				Std.parseInt (behaviorNodeFast.att.width), 
-				Std.parseInt (behaviorNodeFast.att.height), 
-				Std.parseInt (behaviorNodeFast.att.frameX) * -1, 
-				Std.parseInt (behaviorNodeFast.att.frameY) * -1
+				Std.parseInt (behaviorNodeFast.att.height)
 			);
+
+			if (behaviorNodeFast.has.name)
+				frame.name = behaviorNodeFast.att.name;
+
+			if (behaviorNodeFast.has.frameX)
+			{
+					frame.offsetX = Std.parseInt (behaviorNodeFast.att.frameX) * -1;
+					frame.offsetY = Std.parseInt (behaviorNodeFast.att.frameY) * -1;
+			}
 			
 			frameIndex.set (behaviorNodeFast.att.name, i);
 			frames.push (frame);


### PR DESCRIPTION
I implemented this to get performance improvements on the html5 target.  
Lots of individual images result in slow performance when preloading them in the browser.
