### PR TITLE
LibGDX stores the offset from the bottom of the image, not the top. 

### DIFF
--- a/spritesheet/importers/LibGDXImporter.hx
+++ b/spritesheet/importers/LibGDXImporter.hx
@@ -61,7 +61,7 @@ class LibGDXImporter {
 			for (i in 0...frames.length) {
 				
 				var gdxFrame = frames[i];
-				var sFrame = new SpritesheetFrame (gdxFrame.xy.x, gdxFrame.xy.y, gdxFrame.size.w, gdxFrame.size.h, gdxFrame.offset.x, gdxFrame.offset.y);
+				var sFrame = new SpritesheetFrame (gdxFrame.xy.x, gdxFrame.xy.y, gdxFrame.size.w, gdxFrame.size.h, gdxFrame.offset.x, gdxFrame.orig.h - gdxFrame.size.h - gdxFrame.offset.y);
 				sFrame.name = gdxFrame.filename;
 				
 				indexes.push (allFrames.length);


### PR DESCRIPTION
Corrected for that.
