### PR TITLE
Fix for TexturePackerImporter.hx generating non-unique frame IDs

### DIFF
--- a/spritesheet/AnimatedSprite.hx
+++ b/spritesheet/AnimatedSprite.hx
@@ -129,7 +129,18 @@ class AnimatedSprite extends Sprite {
 			
 			var ratio = timeElapsed / loopTime;
 			
-			if (ratio >= 1) {
+			// Number of frames in the animation
+			var frameCount = currentBehavior.frames.length;
+			// Duration in ms of a single frame
+			var frameDuration:Int = Math.floor(loopTime / frameCount);
+			// This is the number of ms we have been in this animation
+			var timeInAnimation:Int = timeElapsed % loopTime;
+			// The raw frame index is the number of frames we have had time to show
+			var rawFrameIndex:Int = Math.floor(timeInAnimation / frameDuration);
+			// Make sure we loop correctly
+			currentFrameIndex = rawFrameIndex % frameCount;
+			
+			if (ratio >= 1 || currentFrameIndex >= (frameCount-1)) {
 				
 				if (currentBehavior.loop) {
 					
@@ -143,17 +154,6 @@ class AnimatedSprite extends Sprite {
 				}
 				
 			}
-			
-			// Number of frames in the animation
-			var frameCount = currentBehavior.frames.length;
-			// Duration in ms of a single frame
-			var frameDuration:Int = Math.round(loopTime / frameCount);
-			// This is the number of ms we have been in this animation
-			var timeInAnimation:Int = timeElapsed % loopTime;
-			// The raw frame index is the number of frames we have had time to show
-			var rawFrameIndex:Int = Math.round(timeInAnimation / frameDuration);
-			// Make sure we loop correctly
-			currentFrameIndex = rawFrameIndex % frameCount;
 			
 			var frame = spritesheet.getFrame (currentBehavior.frames [currentFrameIndex]);
 

--- a/spritesheet/importers/TexturePackerImporter.hx
+++ b/spritesheet/importers/TexturePackerImporter.hx
@@ -95,6 +95,8 @@ class TexturePackerImporter {
         var allBehaviors = new Map <String, BehaviorData>();
         var allRects = new Array<Rectangle>();
 
+		var frameId:Int = 0;
+		
         for (key in behaviorNames.keys()) {
 
             var indexes = new Array<Int>();
@@ -104,7 +106,7 @@ class TexturePackerImporter {
 
                 var tpFrame:TPFrame = frames[i];
                 var sFrame = new SpritesheetFrame ( tpFrame.frame.x, tpFrame.frame.y, tpFrame.frame.w, tpFrame.frame.h );
-                sFrame.id = i;
+                sFrame.id = frameId++;
 
                 if( tpFrame.trimmed )
                 {


### PR DESCRIPTION
Which causes the example project not to display correctly (all animation state behaviors were showing as the same 3 frames).